### PR TITLE
Fix navigation

### DIFF
--- a/app/electron-browser-view.js
+++ b/app/electron-browser-view.js
@@ -186,25 +186,12 @@ class BrowserViewElement extends HTMLElement {
         this.dispatchEvent(new CustomEvent(event, { detail }))
       })
     }
-
-    const src = this.getAttribute('src')
-    if (src) this.loadURL(src)
   }
 
   disconnectedCallback () {
     this.observer.unobserve(this)
     this.view.destroy()
     this.view = null
-  }
-
-  attributeChangedCallback (name, oldValue, newValue) {
-    this.loadURL(newValue)
-  }
-
-  loadURL (url) {
-    if (!this.view) throw new TypeError('View not loaded')
-
-    this.view.webContents.loadURL(url)
   }
 
   resizeView () {

--- a/app/index.html
+++ b/app/index.html
@@ -45,14 +45,11 @@
 	<button id="backbutton" class="hidden">⬅</button>
 	<button id="frontbutton" class="hidden">➡</button>
 	<form id="urlform">
-		<input id="urlbar" value="browser://welcome" />
+		<input id="urlbar" value="agregore-browser://welcome"/>
 		<button id="urlsubmit">◉</button>
 	</form>
 </header>
 
-<browser-view
-	id="view"
-	src="agregore-browser://welcome"
-></browser-view>
+<browser-view id="view"></browser-view>
 
 <script src="script.js"></script>

--- a/app/script.js
+++ b/app/script.js
@@ -7,6 +7,9 @@ webview.addEventListener('dom-ready', () => {
 const urlform = $('#urlform')
 const urlbar = $('#urlbar')
 
+webview.loadURL(urlbar.value)
+webview.focus()
+
 const backbutton = $('#backbutton')
 const frontbutton = $('#frontbutton')
 
@@ -20,21 +23,20 @@ frontbutton.addEventListener('click', () => {
 
 webview.addEventListener('did-start-navigation', ({ detail }) => {
   console.log('Navigating', detail)
-  const url = webview.getURL()
-  urlbar.value = url
 })
 
 webview.addEventListener('did-navigate', updateButtons)
 
 urlform.addEventListener('submit', (e) => {
   e.preventDefault(true)
-  webview.src = urlbar.value
+  webview.loadURL(urlbar.value)
   webview.focus()
 })
 
 function updateButtons () {
   backbutton.classList.toggle('hidden', !webview.canGoBack())
   frontbutton.classList.toggle('hidden', !webview.canGoForward())
+  urlbar.value = webview.getURL()
 }
 
 function $ (query) {


### PR DESCRIPTION
- Remove `attributeChangedCallback` hook from `BrowserViewElement`.
- Remove unused `loadURL` method from `BrowserViewElement`. It gets overwritten in the constructor.
- Remove `src` attribute logic from `connectedCallback` in `BrowserViewElement`.
- Correct `value` attribute in `#urlbar` to reference `agregore-browser` vendor protocol.
- Remove `src` attribute from `#view`.
- Move urlbar update logic from `did-start-navigation` event listener to `did-nagivate` event listener.
- Change `submit` event listener to call `webview.loadURL` directly rather than proxying through the `src` attribute.
- On initial load, call `webview.loadURL` directly.