### PR TITLE
Fix navigation

### DIFF
--- a/app/electron-browser-view.js
+++ b/app/electron-browser-view.js
@@ -197,14 +197,13 @@ class BrowserViewElement extends HTMLElement {
     this.view = null
   }
 
-  attributeChangedCallback (name, oldValue, newValue) {
-    this.loadURL(newValue)
+  static get observedAttributes () {
+    return [ 'src' ]
   }
 
-  loadURL (url) {
-    if (!this.view) throw new TypeError('View not loaded')
-
-    this.view.webContents.loadURL(url)
+  attributeChangedCallback (name, oldValue, newValue) {
+    if (!this.view) return
+    this.loadURL(newValue)
   }
 
   resizeView () {
@@ -215,6 +214,9 @@ class BrowserViewElement extends HTMLElement {
     console.log('New rect', rect)
     this.view.setBounds(rect)
   }
+
+  get src () { return this.getAttribute('src') }
+  set src (url) { this.setAttribute('src', url) }
 
   get audioMuted () { return this.view.webContents.audioMuted }
   set audioMuted (audioMuted) { this.view.webContents.audioMuted = audioMuted }

--- a/app/index.html
+++ b/app/index.html
@@ -45,7 +45,7 @@
 	<button id="backbutton" class="hidden">⬅</button>
 	<button id="frontbutton" class="hidden">➡</button>
 	<form id="urlform">
-		<input id="urlbar" value="browser://welcome" />
+		<input id="urlbar"/>
 		<button id="urlsubmit">◉</button>
 	</form>
 </header>

--- a/app/script.js
+++ b/app/script.js
@@ -20,8 +20,6 @@ frontbutton.addEventListener('click', () => {
 
 webview.addEventListener('did-start-navigation', ({ detail }) => {
   console.log('Navigating', detail)
-  const url = webview.getURL()
-  urlbar.value = url
 })
 
 webview.addEventListener('did-navigate', updateButtons)
@@ -35,6 +33,7 @@ urlform.addEventListener('submit', (e) => {
 function updateButtons () {
   backbutton.classList.toggle('hidden', !webview.canGoBack())
   frontbutton.classList.toggle('hidden', !webview.canGoForward())
+  urlbar.value = webview.getURL()
 }
 
 function $ (query) {


### PR DESCRIPTION
- Remove unused `loadURL` method from `BrowserViewElement`. It gets overwritten in the constructor.
- Add `src` shorthand getter and setter to `BrowserViewElement`.
- Add static `observedAttributes` getter to `BrowserViewElement`. Observe the `src` attribute.
- Bail from `attributeChangedCallback` if the `BrowserViewElement` instance hasn't been connected.
- Move urlbar update logic from `did-start-navigation` event listener to `did-navigate` event listener.
- Remove the inline `value` attribute from `#urlbar`.