### PR TITLE
Add debug mode

### DIFF
--- a/app/electron-browser-view.js
+++ b/app/electron-browser-view.js
@@ -157,7 +157,7 @@ class BrowserViewElement extends HTMLElement {
   constructor () {
     super()
 
-    console.log('Initializng', this)
+    console.debug('Initializng', this)
 
     this.view = null
 
@@ -169,7 +169,7 @@ class BrowserViewElement extends HTMLElement {
   }
 
   connectedCallback () {
-    console.log('Connected', this)
+    console.debug('Connected', this)
     this.observer.observe(this)
 
     const remote = require('electron').remote
@@ -211,7 +211,7 @@ class BrowserViewElement extends HTMLElement {
 
     const rect = this.getBoundingClientRect()
 
-    console.log('New rect', rect)
+    console.debug('New rect', rect)
     this.view.setBounds(rect)
   }
 

--- a/app/main.js
+++ b/app/main.js
@@ -32,7 +32,9 @@ function createWindow () {
   win.loadFile(MAIN_PAGE)
 
   // Open the DevTools.
-  win.webContents.openDevTools()
+  if (process.env.MODE == 'debug') {
+    win.webContents.openDevTools()
+  }
 }
 
 protocol.registerSchemesAsPrivileged([

--- a/app/script.js
+++ b/app/script.js
@@ -1,7 +1,9 @@
 const webview = $('#view')
 
 webview.addEventListener('dom-ready', () => {
-  webview.openDevTools()
+  if (process.env.MODE == 'debug') {
+    webview.openDevTools()
+  }
 })
 
 const urlform = $('#urlform')
@@ -19,7 +21,7 @@ frontbutton.addEventListener('click', () => {
 })
 
 webview.addEventListener('did-start-navigation', ({ detail }) => {
-  console.log('Navigating', detail)
+  console.debug('Navigating', detail)
 })
 
 webview.addEventListener('did-navigate', updateButtons)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron .",
+    "debug": "env MODE=debug electron .",
     "electron-rebuild": "electron-rebuild",
     "build": "electron-builder build -mwl --publish never"
   },


### PR DESCRIPTION
- Activate debug mode by setting `MODE` environment variable to `debug`.
- Add npm `debug` script that will start the application with `MODE=debug`.
- Only open the dev tools on load if `MODE` is set to `debug`.
- Change `console.log` calls throughout `BrowserViewElement` to `console.debug`.