### PR TITLE
Fix extensions ruining top bar

### DIFF
--- a/app/ui/index.html
+++ b/app/ui/index.html
@@ -18,9 +18,12 @@
 <script src="./browser-actions.js"></script>
 
 <header id="top">
-  <find-menu id="find" class="hidden"></find-menu>
-  <omni-box id="search"></omni-box>
-  <browser-actions></browser-actions>
+  <section id="toptop">
+    <find-menu id="find" class="hidden"></find-menu>
+    <omni-box id="search" nav-options-id="nav-options"></omni-box>
+    <browser-actions></browser-actions>
+  </section>
+  <section class="nav-options" id="nav-options" aria-live="polite"></section>
 </header>
 
 <tracked-box tabindex="0" id="view"></tracked-box>

--- a/app/ui/omni-box.js
+++ b/app/ui/omni-box.js
@@ -7,6 +7,10 @@ class OmniBox extends HTMLElement {
     this.lastSearch = 0
   }
 
+  get options() {
+    return document.querySelector('#' + this.getAttribute('nav-options-id'))
+  }
+
   connectedCallback () {
     this.innerHTML = `
       <section class="omni-box-header">
@@ -17,13 +21,11 @@ class OmniBox extends HTMLElement {
           <button class="omni-box-button" type="submit" title="Load page or Reload">⊚</button>
         </form>
       </section>
-      <section class="omni-box-nav-options" aria-live="polite"></section>
     `
     this.backButton = this.$('.omni-box-back')
     this.forwardButton = this.$('.omni-box-forward')
     this.form = this.$('.omni-box-form')
     this.input = this.$('.omni-box-input')
-    this.options = this.$('.omni-box-nav-options')
 
     this.input.addEventListener('focus', () => {
       this.input.select()

--- a/app/ui/style.css
+++ b/app/ui/style.css
@@ -21,7 +21,7 @@ html, body {
   flex:1
 }
 
-#top {
+#toptop {
   display: flex;
   flex-direction: row;
   height: var(--top-height);
@@ -64,7 +64,7 @@ omni-box {
   font-family: inherit;
 }
 
-.omni-box-nav-options {
+.nav-options {
   display: flex;
   flex-direction: column;
   margin: 0px;
@@ -74,11 +74,11 @@ omni-box {
   color: var(--ag-theme-text);
 }
 
-.omni-box-nav-options [data-selected] {
+.nav-options [data-selected] {
   border: 1px solid var(--ag-theme-secondary);
 }
 
-.omni-box-nav-options:empty {
+.nav-options:empty {
   display: none;
 }
 

--- a/app/ui/style.css
+++ b/app/ui/style.css
@@ -1,8 +1,8 @@
 @import url("agregore://theme/vars.css");
 
 :root {
-  --top-height: 40px;
-  --border-width: 2px;
+  --top-height: 2.5em;
+  --border-width: 0.125em;
 }
 
 html, body {

--- a/app/ui/style.css
+++ b/app/ui/style.css
@@ -1,24 +1,30 @@
 @import url("agregore://theme/vars.css");
 
+:root {
+  --top-height: 40px;
+  --border-width: 2px;
+}
+
 html, body {
-	width: 100%;
-	height: 100%;
-	padding: 0;
-	margin: 0;
-	display: flex;
-	flex: 1;
-	flex-direction: column;
-	background: var(--ag-color-white);
-	font-family: var(--ag-theme-font-family);
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  background: var(--ag-color-white);
+  font-family: var(--ag-theme-font-family);
 }
 
 #view {
-	flex:1
+  flex:1
 }
 
 #top {
   display: flex;
   flex-direction: row;
+  height: var(--top-height);
 }
 
 #search {
@@ -26,7 +32,7 @@ html, body {
 }
 
 .hidden {
-	display: none !important;
+  display: none !important;
 }
 
 omni-box {
@@ -34,42 +40,42 @@ omni-box {
 }
 
 .omni-box-header {
-	display: flex;
-	flex-direction: row;
-	border-bottom: 2px solid var(--ag-theme-primary);
-	background: var(--ag-theme-background);
-	color: var(--ag-theme-text);
+  display: flex;
+  flex-direction: row;
+  border-bottom: var(--border-width) solid var(--ag-theme-primary);
+  background: var(--ag-theme-background);
+  color: var(--ag-theme-text);
 }
 
 .omni-box-form, .find-menu-form {
-	display: flex;
-	flex-direction: row;
-	flex:1;
-	border: none;
+  display: flex;
+  flex-direction: row;
+  flex:1;
+  border: none;
 }
 
 .omni-box-input, .find-menu-input {
-	flex: 1;
-	border:none;
-	background: none;
-	padding: 0.5em;
-	color: inherit;
-	font-size: inherit;
-	font-family: inherit;
+  flex: 1;
+  border:none;
+  background: none;
+  padding: 0.5em;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
 }
 
 .omni-box-nav-options {
-	display: flex;
-	flex-direction: column;
-	margin: 0px;
-	padding: 0px;
-	border: 2px solid var(--ag-theme-primary);
-	background: var(--ag-theme-background);
-	color: var(--ag-theme-text);
+  display: flex;
+  flex-direction: column;
+  margin: 0px;
+  padding: 0px;
+  border: var(--border-width) solid var(--ag-theme-primary);
+  background: var(--ag-theme-background);
+  color: var(--ag-theme-text);
 }
 
 .omni-box-nav-options [data-selected] {
-	border: 1px solid var(--ag-theme-secondary);
+  border: 1px solid var(--ag-theme-secondary);
 }
 
 .omni-box-nav-options:empty {
@@ -86,35 +92,42 @@ omni-box {
 }
 
 .omni-box-nav-item {
-	border: 1px solid var(--ag-theme-primary);
-	display: flex;
-	flex-direction: row;
-	overflow: hidden;
+  border: 1px solid var(--ag-theme-primary);
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
 find-menu {
-	border: 2px solid var(--ag-theme-primary);
-	border-top: none;
-	display: flex;
-	flex-direction: row;
-	background: var(--ag-theme-background);
-	color: var(--ag-theme-text);
+  border: var(--border-width) solid var(--ag-theme-primary);
+  border-top: none;
+  display: flex;
+  flex-direction: row;
+  background: var(--ag-theme-background);
+  color: var(--ag-theme-text);
 }
 
 browser-actions {
-	border: 2px solid var(--ag-theme-primary);
-	display: flex;
-	flex-direction: row;
-	background: var(--ag-theme-background);
-	color: var(--ag-theme-text);
-	justify-content: center;
+  height: calc(var(--top-height) - calc(var(--border-width) * 3));
+  border-bottom: var(--border-width) solid var(--ag-theme-primary);
+  border-left: var(--border-width) solid var(--ag-theme-primary);
+  display: flex;
+  flex-direction: row;
+  background: var(--ag-theme-background);
+  color: var(--ag-theme-text);
+  justify-content: center;
   align-items: center;
+  padding: var(--border-width);
 }
-
 .browser-actions-button {
-  padding: 0 0.25em;
+  padding: 0 calc(var(--border-width) * 2);
+  height: calc(100% - calc(var(--border-width) * 2));
+  width: auto;
+} .browser-actions-button>img {
+  height: 100%;
+  width: auto;
 }
 
 browser-actions:empty {
@@ -122,5 +135,5 @@ browser-actions:empty {
 }
 
 *:focus {
-  outline: 2px solid var(--ag-theme-secondary);
+  outline: var(--border-width) solid var(--ag-theme-secondary);
 }


### PR DESCRIPTION
Extensions buttons were unrestricted and thus large images were able to ruin the top bar.

I've limited their height and defined the top bar height.

As well as this, I've variablised borders and cleaned up tabs/space mixup, preferring the repo norm of two spaces.

Relates to #50.